### PR TITLE
Field customization

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -129,6 +129,15 @@ class MyHomePage extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: 15),
+                  FormBuilderImagePicker(
+                    name: 'fieldCustomization',
+                    decoration: const InputDecoration(labelText: 'Pick Photos'),
+                    previewAutoSizeWidth: true,
+                    fit: BoxFit.cover,
+                    backgroundColor: Colors.black54,
+                    iconColor: Colors.white,
+                    icon: Icons.ac_unit_rounded,
+                  ),
                   ElevatedButton(
                     child: const Text('Submit'),
                     onPressed: () {

--- a/lib/src/form_builder_image_picker.dart
+++ b/lib/src/form_builder_image_picker.dart
@@ -42,7 +42,14 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
   /// placeholder widget displayed when picking a new image
   final Widget? placeholderWidget;
 
+  /// Field icon
+  final IconData? icon;
+
+  /// Field icon color
   final Color? iconColor;
+
+  /// Field background color
+  final Color? backgroundColor;
 
   /// Optional maximum height of image; see [ImagePicker].
   final double? maxHeight;
@@ -113,7 +120,9 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
     this.previewWidth = 130,
     this.previewHeight = 130,
     this.previewMargin,
+    this.icon,
     this.iconColor,
+    this.backgroundColor,
     this.maxHeight,
     this.maxWidth,
     this.imageQuality,
@@ -165,11 +174,11 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
                               )
                             : Container(
                                 color: (state.enabled
-                                        ? iconColor ?? primaryColor
-                                        : disabledColor)
-                                    .withAlpha(50),
+                                    ? backgroundColor ??
+                                        primaryColor.withAlpha(50)
+                                    : disabledColor),
                                 child: Icon(
-                                  Icons.camera_enhance,
+                                  icon ?? Icons.camera_enhance,
                                   color: state.enabled
                                       ? iconColor ?? primaryColor
                                       : disabledColor,


### PR DESCRIPTION


## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #35 

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected to #5 

## Solution description

Allow to choose a custom:
- `icon` (of `IconData?` type)
- `iconColor` (of `Color?` type)
- `backgroundColor` (of `Color?` type).

If none of these are provided, it defaults to the usual `Icons.camera_enhance` and `primary` color option.

## Screenshots or Videos

![example_field_customization](https://user-images.githubusercontent.com/8938540/185153575-16615681-422a-4ceb-a4db-5bb4dc1eceb7.png)

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme

## Misc

Adds an example of field customization in example and updates `AndroidManifest.xml` for it to compile.