### PR TITLE
Allow only camera or gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ ___
 - [Use](#use)
     - [Setup](#setup)
     - [Basic use](#basic-use)
-    - [Especific uses](#especific-uses)
 - [Support](#support)
     - [Contribute](#contribute)
     - [Questions and answers](#questions-and-answers)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ___
 
 Since this package makes use of [image_picker](https://pub.dev/packages/image_picker) package, for platform specific setup, follow the instructions [here](https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker#installation)
 
-### Basuc use
+### Basic use
 
 ```dart
 FormBuilder(
@@ -53,7 +53,7 @@ FormBuilder(
 ),
 ```
 
-See [pud.dev example tab](https://pub.dev/packages/form_builder_image_picker/example) or [github code](example/lib/main.dart) for more details
+See [pub.dev example tab](https://pub.dev/packages/form_builder_image_picker/example) or [github code](example/lib/main.dart) for more details
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ FormBuilder(
 ),
 ```
 
+### Only specific pickers
+```dart
+FormBuilder(
+  child: Column(
+    mainAxisAlignment: MainAxisAlignment.center,
+    children: <Widget>[
+      FormBuilderImagePicker(
+        name: 'noCamera',
+        availableImageSources: const [ImageSourceOption.gallery],
+      ),
+    ],
+  ),
+),
+```
+
 See [pub.dev example tab](https://pub.dev/packages/form_builder_image_picker/example) or [github code](example/lib/main.dart) for more details
 
 ## Support

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,7 @@ class MyApp extends StatelessWidget {
 class ApiImage {
   final String imageUrl;
   final String id;
+
   ApiImage({
     required this.imageUrl,
     required this.id,
@@ -137,6 +138,20 @@ class MyHomePage extends StatelessWidget {
                     backgroundColor: Colors.black54,
                     iconColor: Colors.white,
                     icon: Icons.ac_unit_rounded,
+                  ),
+                  const SizedBox(height: 15),
+                  FormBuilderImagePicker(
+                    name: 'onlyCamera',
+                    decoration: const InputDecoration(
+                        labelText: 'Pick Photos (only from camera)'),
+                    availableImageSources: const [ImageSourceOption.camera],
+                  ),
+                  const SizedBox(height: 15),
+                  FormBuilderImagePicker(
+                    name: 'onlyGallery',
+                    decoration: const InputDecoration(
+                        labelText: 'Pick Photos (only from gallery)'),
+                    availableImageSources: const [ImageSourceOption.gallery],
                   ),
                   ElevatedButton(
                     child: const Text('Submit'),

--- a/lib/form_builder_image_picker.dart
+++ b/lib/form_builder_image_picker.dart
@@ -1,3 +1,4 @@
 library form_builder_image_picker;
 
 export 'src/form_builder_image_picker.dart';
+export 'src/image_source_option.dart';

--- a/lib/src/form_builder_image_picker.dart
+++ b/lib/src/form_builder_image_picker.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'image_source_option.dart';
 import 'image_source_sheet.dart';
 
 /// Field for picking image(s) from Gallery or Camera.
@@ -95,6 +96,10 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
   /// fit for each image
   final BoxFit fit;
 
+  /// The sources available to pick from.
+  /// Either [ImageSourceOption.gallery], [ImageSourceOption.camera] or both.
+  final List<ImageSourceOption> availableImageSources;
+
   FormBuilderImagePicker({
     Key? key,
     //From Super
@@ -135,6 +140,10 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
     this.galleryLabel = const Text('Gallery'),
     this.bottomSheetPadding = EdgeInsets.zero,
     this.placeholderImage,
+    this.availableImageSources = const [
+      ImageSourceOption.camera,
+      ImageSourceOption.gallery,
+    ],
   })  : assert(maxImages == null || maxImages >= 0),
         super(
           key: key,
@@ -203,6 +212,7 @@ class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
                           cameraLabel: cameraLabel,
                           galleryIcon: galleryIcon,
                           galleryLabel: galleryLabel,
+                          availableImageSources: availableImageSources,
                           onImageSelected: (image) {
                             state.requestFocus();
                             field.didChange([...value, ...image]);

--- a/lib/src/image_source_option.dart
+++ b/lib/src/image_source_option.dart
@@ -1,0 +1,10 @@
+/// Options where a user can pick images from
+enum ImageSourceOption {
+  /// From the device camera
+  /// (via [ImageSource.camera])
+  camera,
+
+  /// From the gallery (or local files on the web)
+  /// (via [ImageSource.gallery])
+  gallery
+}

--- a/lib/src/image_source_sheet.dart
+++ b/lib/src/image_source_sheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 
+import 'image_source_option.dart';
+
 class ImageSourceBottomSheet extends StatefulWidget {
   /// Optional maximum height of image
   final double? maxHeight;
@@ -24,6 +26,10 @@ class ImageSourceBottomSheet extends StatefulWidget {
   /// Callback when an image is selected.
   final void Function(Iterable<XFile> files) onImageSelected;
 
+  /// The sources to create ListTiles for.
+  /// Either [ImageSourceOption.gallery], [ImageSourceOption.camera] or both.
+  final List<ImageSourceOption> availableImageSources;
+
   final Widget? cameraIcon;
   final Widget? galleryIcon;
   final Widget? cameraLabel;
@@ -45,6 +51,7 @@ class ImageSourceBottomSheet extends StatefulWidget {
     this.cameraLabel,
     this.galleryLabel,
     this.bottomSheetPadding,
+    required this.availableImageSources,
   }) : super(key: key);
 
   @override
@@ -94,16 +101,18 @@ class ImageSourceBottomSheetState extends State<ImageSourceBottomSheet> {
       padding: widget.bottomSheetPadding,
       child: Wrap(
         children: <Widget>[
-          ListTile(
-            leading: widget.cameraIcon,
-            title: widget.cameraLabel,
-            onTap: () => _onPickImage(ImageSource.camera),
-          ),
-          ListTile(
-            leading: widget.galleryIcon,
-            title: widget.galleryLabel,
-            onTap: () => _onPickImage(ImageSource.gallery),
-          ),
+          if (widget.availableImageSources.contains(ImageSourceOption.camera))
+            ListTile(
+              leading: widget.cameraIcon,
+              title: widget.cameraLabel,
+              onTap: () => _onPickImage(ImageSource.camera),
+            ),
+          if (widget.availableImageSources.contains(ImageSourceOption.gallery))
+            ListTile(
+              leading: widget.galleryIcon,
+              title: widget.galleryLabel,
+              onTap: () => _onPickImage(ImageSource.gallery),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #23

## Solution description
You can specify from which sources a user can select images, by setting them manually via `availableImageSources = [ImageSourceOption.camera, ImageSourceOption.gallery]` 

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->
![only camera](https://user-images.githubusercontent.com/45557700/202259932-8034ff3b-ea60-4650-b406-94e080f3d1d9.png)
![only gallery](https://user-images.githubusercontent.com/45557700/202259985-e469ac93-b5c9-48ee-87f2-287605083f50.png)


## To Do

- [X] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [X] Check the original issue to confirm it is fully satisfied
- [X] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [X] If apply, add documentation to code properties and package readme

