### PR TITLE
feat: expose state in ImagePicker previewBuilder

### DIFF
--- a/lib/src/form_builder_image_picker.dart
+++ b/lib/src/form_builder_image_picker.dart
@@ -42,6 +42,7 @@ class FormBuilderImagePicker extends FormBuilderFieldDecoration<List<dynamic>> {
     BuildContext,
     List<Widget> children,
     Widget? addButton,
+    FormBuilderImagePickerState state,
   )? previewBuilder;
 
   /// placeholder image displayed when picking a new image
@@ -332,6 +333,7 @@ class FormBuilderImagePicker extends FormBuilderFieldDecoration<List<dynamic>> {
                   context,
                   widgets,
                   canUpload ? addButtonBuilder(context) : null,
+                  state,
                 );
               });
             }


### PR DESCRIPTION
Enables custom previewBuilder implementations to access validation state and error messages. This makes it possible to display validation errors with custom preview layouts, which wasn't previously possible.

## To Do

- [ ] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [ ] Check the original issue to confirm it is fully satisfied
- [ ] Add solution description to help guide reviewers
- [ ] Add unit test to verify new or fixed behaviour
- [ ] If apply, add documentation to code properties and package readme
